### PR TITLE
change useEffect second argument to allow for comparrison

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -61,7 +61,7 @@ export function useResponsiveSVGSelection<T>(
         .selectAll('*')
         .remove();
     };
-  }, [initialSize, minSize]);
+  }, [initialSize[0], initialSize[1], minSize[0], minSize[1]]);
 
   return [elementRef, selection, size];
 }


### PR DESCRIPTION
This change prevents the problem described here: https://github.com/chrisrzhou/react-wordcloud/issues/25#issue-521251684