### PR TITLE
Add tooltipProps to pass props to tippy

### DIFF
--- a/docs/usage/options.mdx
+++ b/docs/usage/options.mdx
@@ -125,8 +125,8 @@ Use the Playground to edit and play around with some of these options!
 				"#9467bd",
 				"#8c564b",
 			],
-			enableTooltip: true,
 			deterministic: false,
+			enableTooltip: true,
 			fontFamily: "impact",
 			fontSizes: [5, 60],
 			fontStyle: "normal",
@@ -137,6 +137,11 @@ Use the Playground to edit and play around with some of these options!
 			rotationAngles: [0, 90],
 			scale: "sqrt",
 			spiral: "archimedean",
+			tooltipOptions: {
+				allowHTML: true,
+				arrow: false,
+				placement: "bottom",
+			},
 			transitionDuration: 1000,
 		}}
 	/>

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export const defaultOptions = {
 	rotationAngles: [-90, 90],
 	scale: 'sqrt',
 	spiral: 'rectangular',
+	tooltipOptions: {},
 	transitionDuration: 600,
 };
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -25,7 +25,13 @@ export function render({ callbacks, options, random, selection, words }) {
 		onWordMouseOver,
 		onWordMouseOut,
 	} = callbacks;
-	const { colors, enableTooltip, fontStyle, fontWeight } = options;
+	const {
+		colors,
+		enableTooltip,
+		tooltipOptions,
+		fontStyle,
+		fontWeight,
+	} = options;
 	const { fontFamily, transitionDuration } = options;
 
 	function getFill(word) {
@@ -50,6 +56,7 @@ export function render({ callbacks, options, random, selection, words }) {
 							animation: 'scale',
 							arrow: true,
 							content: () => getWordTooltip(word),
+							...tooltipOptions,
 						});
 					}
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import { EnterElement, Selection as d3Selection } from 'd3-selection';
+import { Props as TippyProps } from 'tippy.js';
 
 export interface Callbacks {
 	/**
@@ -82,6 +83,12 @@ export interface Options {
 	 * Control the spiral pattern on how words are laid out.
 	 */
 	spiral: Spiral;
+	/**
+	 * Additional props object to pass to the tooltip library. For more details,
+	 * refer to the documentation for
+	 * [Tippy.js Props](https://atomiks.github.io/tippyjs/v6/all-props/).
+	 */
+	tooltipOptions: TippyProps;
 	/**
 	 * Sets the animation transition time in milliseconds.
 	 */


### PR DESCRIPTION
This adds an option `tooltipProps` which are passed through to the underlying Tippy.js library so it's possible to customise any and all the various [props supported by Tippy](https://atomiks.github.io/tippyjs/v6/all-props/). The spread operator is used to augment the default props being set, meaning that the defaults (e.g. `arrow: true` can be overridden).  In my specific case, I was mostly chasing access to the `allowHTML` and `position` props so I can fully customise the internals of the tooltip; only text-based content & the default positioning was previously possible.

I'm new to TS so let me know if this PR needs any adjustment.