### PR TITLE
Pass through props to wordcloud element

### DIFF
--- a/docs/props/props.mdx
+++ b/docs/props/props.mdx
@@ -17,6 +17,8 @@ import ReactWordcloud from "../..";
 
 <Props of={ComponentProps} />
 
+Additional props will be passed through to the underlying HTML element.
+
 ## `Word`
 
 The `word` object takes the following shape

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ function ReactWordCloud({
 	options,
 	size: initialSize,
 	words,
+	...passThroughProps
 }) {
 	const mergedCallbacks = { ...defaultCallbacks, ...callbacks };
 	const mergedOptions = { ...defaultOptions, ...options };
@@ -59,7 +60,13 @@ function ReactWordCloud({
 		}
 	}, [maxWords, mergedCallbacks, mergedOptions, selection, size, words]);
 
-	return <div ref={ref} style={{ height: '100%', width: '100%' }} />;
+	return (
+		<div
+			ref={ref}
+			style={{ height: '100%', width: '100%' }}
+			{...passThroughProps}
+		/>
+	);
 }
 
 ReactWordCloud.defaultProps = {


### PR DESCRIPTION
This passes through all other props through to the underlying element, allowing props like ``className``, ``style``, and anything else HTML or React-related to be passed through.

I've added a note about this behaviour to the documentation as I'm not sure how something like this gets represented in a TS interface - I'm completely new to TS.