### PR TITLE
Docs: convert tabs to spaces

### DIFF
--- a/docs/usage/basic.mdx
+++ b/docs/usage/basic.mdx
@@ -15,5 +15,5 @@ import words from "../words";
 Simply provide an array of words with valid `text` and `value` fields to begin!
 
 <Playground>
-	<ReactWordcloud words={words} />
+  <ReactWordcloud words={words} />
 </Playground>

--- a/docs/usage/callbacks.mdx
+++ b/docs/usage/callbacks.mdx
@@ -22,14 +22,14 @@ By default, `react-wordcloud` randomnly applies colors to words using colors fro
 In the example below, we can pass custom `getWordColor` and `getWordTooltip` callbacks to update word colors and tooltips based on the `word` data.
 
 <Playground>
-	<ReactWordcloud
-		words={words}
-		callbacks={{
-			getWordColor: ({ value }) => (value > 50 ? "blue" : "red"),
-			getWordTooltip: ({ text, value }) =>
-				`${text} (${value}) [${value > 50 ? "good" : "bad"}]`,
-		}}
-	/>
+  <ReactWordcloud
+    words={words}
+    callbacks={{
+      getWordColor: ({ value }) => (value > 50 ? "blue" : "red"),
+      getWordTooltip: ({ text, value }) =>
+        `${text} (${value}) [${value > 50 ? "good" : "bad"}]`,
+    }}
+  />
 </Playground>
 
 ## Mouse Events
@@ -37,31 +37,31 @@ In the example below, we can pass custom `getWordColor` and `getWordTooltip` cal
 You can pass callbacks such as `onWordClick`, `onWordMouseEnter` and `onWordMouseLeave` to capture the word and mouse events. The following example shows how we can work with the captured word and mouse events to create an enlarged word that opens an external link.
 
 <Playground>
-	{() => {
-		const getCallback = callbackName => (word, event) => {
-			const isActive = callbackName !== "onWordMouseOut";
-			const element = event.target;
-			const text = select(element);
-			text
-				.on("click", () => {
-					if (isActive) {
-						window.open(`https://duckduckgo.com/?q=${word.text}`, "_blank");
-					}
-				})
-				.transition()
-				.attr("background", "white")
-				.attr("font-size", isActive ? "300%" : "100%")
-				.attr("text-decoration", isActive ? "underline" : "none");
-		};
-		return (
-			<ReactWordcloud
-				callbacks={{
-					onWordClick: getCallback("onWordClick"),
-					onWordMouseOut: getCallback("onWordMouseOut"),
-					onWordMouseOver: getCallback("onWordMouseOver"),
-				}}
-				words={words}
-			/>
-		);
-	}}
+  {() => {
+    const getCallback = callbackName => (word, event) => {
+      const isActive = callbackName !== "onWordMouseOut";
+      const element = event.target;
+      const text = select(element);
+      text
+        .on("click", () => {
+          if (isActive) {
+            window.open(`https://duckduckgo.com/?q=${word.text}`, "_blank");
+          }
+        })
+        .transition()
+        .attr("background", "white")
+        .attr("font-size", isActive ? "300%" : "100%")
+        .attr("text-decoration", isActive ? "underline" : "none");
+    };
+    return (
+      <ReactWordcloud
+        callbacks={{
+          onWordClick: getCallback("onWordClick"),
+          onWordMouseOut: getCallback("onWordMouseOut"),
+          onWordMouseOver: getCallback("onWordMouseOver"),
+        }}
+        words={words}
+      />
+    );
+  }}
 </Playground>

--- a/docs/usage/options.mdx
+++ b/docs/usage/options.mdx
@@ -19,12 +19,12 @@ You can customize many visual and layout properties of `react-wordcloud` by usin
 `react-wordcloud` will randomnly apply colors from an array of color hex codes.
 
 <Playground>
-	<ReactWordcloud
-		options={{
-			colors: ["#1f77b4", "#9467bd", "#8c564b"],
-		}}
-		words={words}
-	/>
+  <ReactWordcloud
+    options={{
+      colors: ["#1f77b4", "#9467bd", "#8c564b"],
+    }}
+    words={words}
+  />
 </Playground>
 
 ## Deterministic Behaviour
@@ -32,13 +32,13 @@ You can customize many visual and layout properties of `react-wordcloud` by usin
 `react-wordcloud` randomly positions and rotates words by default. If `options.deterministic` is `true`, `react-wordcloud` will produce the same positioning/rotation/color for a provided input. You can also provide a `randomSeed` string value to control the random seed behavior.  Try resizing the wordcloud up and down in the example below to see the deterministic behavior.
 
 <Playground>
-	<ReactWordcloud
-		options={{
-			deterministic: true,
-			randomSeed: 'seed1',
-		}}
-		words={words}
-	/>
+  <ReactWordcloud
+    options={{
+      deterministic: true,
+      randomSeed: 'seed1',
+    }}
+    words={words}
+  />
 </Playground>
 
 ## Font Styles
@@ -46,15 +46,15 @@ You can customize many visual and layout properties of `react-wordcloud` by usin
 Configure word font styles using the `fontFamily`, `fontSizes`, `fontStyle`, `fontWeight` options.
 
 <Playground>
-	<ReactWordcloud
-		options={{
-			fontFamily: "courier new",
-			fontSizes: [10, 20],
-			fontStyle: "italic",
-			fontWeight: "bold",
-		}}
-		words={words}
-	/>
+  <ReactWordcloud
+    options={{
+      fontFamily: "courier new",
+      fontSizes: [10, 20],
+      fontStyle: "italic",
+      fontWeight: "bold",
+    }}
+    words={words}
+  />
 </Playground>
 
 ## Rotations
@@ -63,37 +63,37 @@ By default `react-wordcloud` will apply random rotations if the `rotations` opti
 
 <Playground>
   <h3>Auto</h3>
-	<ReactWordcloud
+  <ReactWordcloud
     size={[600, 400]}
-		words={words}
-	/>
+    words={words}
+  />
   <h3>0º</h3>
-	<ReactWordcloud
-		options={{
-			rotations: 1,
-			rotationAngles: [0, 0],
-		}}
+  <ReactWordcloud
+    options={{
+      rotations: 1,
+      rotationAngles: [0, 0],
+    }}
     size={[600, 400]}
-		words={words}
-	/>
+    words={words}
+  />
   <h3>0º, 90º (negative angles work too)</h3>
-	<ReactWordcloud
-		options={{
-			rotations: 2,
-			rotationAngles: [-90, 0],
-		}}
+  <ReactWordcloud
+    options={{
+      rotations: 2,
+      rotationAngles: [-90, 0],
+    }}
     size={[600, 400]}
-		words={words}
-	/>
+    words={words}
+  />
   <h3>0º, 45º, 90º</h3>
-	<ReactWordcloud
-		options={{
-			rotations: 3,
-			rotationAngles: [0, 90],
-		}}
+  <ReactWordcloud
+    options={{
+      rotations: 3,
+      rotationAngles: [0, 90],
+    }}
     size={[600, 400]}
-		words={words}
-	/>
+    words={words}
+  />
 </Playground>
 
 ## Layout
@@ -101,13 +101,13 @@ By default `react-wordcloud` will apply random rotations if the `rotations` opti
 Configure the wordcloud layout by using the `scale`, `spiral` options.
 
 <Playground>
-	<ReactWordcloud
-		options={{
-			scale: "log",
-			spiral: "rectangular",
-		}}
-		words={words}
-	/>
+  <ReactWordcloud
+    options={{
+      scale: "log",
+      spiral: "rectangular",
+    }}
+    words={words}
+  />
 </Playground>
 
 ## Attributes
@@ -115,19 +115,19 @@ Configure the wordcloud layout by using the `scale`, `spiral` options.
 You can set custom attributes on the `svg` or `text` nodes by using the `svgAttributes` or `textAttributes`.  You can either use a string or a function returning a string from a `Word` as values for attributes.  You may also override the existing attributes that are set by the wordcloud algorithm.  These features are demonstrated in the example below.
 
 <Playground>
-	<ReactWordcloud
-		options={{
-			svgAttributes: {
+  <ReactWordcloud
+    options={{
+      svgAttributes: {
         role: 'list',
       },
-			textAttributes: {
+      textAttributes: {
         'aria-label': word => `Word: "${word.text}", Count: "${word.value}"`,
         fill: 'red',
         role: 'img',
       },
-		}}
-		words={words}
-	/>
+    }}
+    words={words}
+  />
 </Playground>
 
 ## Interactive
@@ -135,42 +135,42 @@ You can set custom attributes on the `svg` or `text` nodes by using the `svgAttr
 Use the Playground to edit and play around with some of these options!
 
 <Playground>
-	<ReactWordcloud
-		words={words}
-		options={{
-			colors: [
-				"#1f77b4",
-				"#ff7f0e",
-				"#2ca02c",
-				"#d62728",
-				"#9467bd",
-				"#8c564b",
-			],
-			deterministic: false,
-			enableTooltip: true,
-			fontFamily: "impact",
-			fontSizes: [5, 60],
-			fontStyle: "normal",
-			fontWeight: "normal",
-			padding: 1,
-			randomSeed: null,
-			rotations: 3,
-			rotationAngles: [0, 90],
-			scale: "sqrt",
-			spiral: "archimedean",
+  <ReactWordcloud
+    words={words}
+    options={{
+      colors: [
+        "#1f77b4",
+        "#ff7f0e",
+        "#2ca02c",
+        "#d62728",
+        "#9467bd",
+        "#8c564b",
+      ],
+      deterministic: false,
+      enableTooltip: true,
+      fontFamily: "impact",
+      fontSizes: [5, 60],
+      fontStyle: "normal",
+      fontWeight: "normal",
+      padding: 1,
+      randomSeed: null,
+      rotations: 3,
+      rotationAngles: [0, 90],
+      scale: "sqrt",
+      spiral: "archimedean",
       svgAttributes: {
         role: 'list',
       },
-			textAttributes: {
+      textAttributes: {
         'aria-label': word => `Word: "${word.text}", Count: "${word.value}"`,
         role: 'img',
       },
-			tooltipOptions: {
-				allowHTML: true,
-				arrow: false,
-				placement: "bottom",
-			},
-			transitionDuration: 1000,
-		}}
-	/>
+      tooltipOptions: {
+        allowHTML: true,
+        arrow: false,
+        placement: "bottom",
+      },
+      transitionDuration: 1000,
+    }}
+  />
 </Playground>


### PR DESCRIPTION
This replaces the last tabs in the project, which are just in a few documentation files.  The other space-indented code in the docs was using 2-spaces in place of tabs so this follows the same formatting.