### PR TITLE
Add CSS imports for 1.2.7 to readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@ Note that `react-wordcloud` requires `react^16.13.0` as a peer dependency.
 ```js
 import React from 'react';
 import ReactWordcloud from 'react-wordcloud';
+import 'tippy.js/dist/tippy.css';
+import 'tippy.js/animations/scale.css';
 
 const words = [
   {
@@ -43,6 +45,8 @@ function SimpleWordcloud() {
   return <ReactWordcloud words={words} />
 }
 ```
+
+By default, `ReactWordcloud` is configured with animated tooltips enabled and requires CSS for styling. Tippy provides base styling in the resources above or you can create your own.
 
 ### Kitchen Sink
 


### PR DESCRIPTION
This adds the required CSS changes to the simple example in the README where tooltips will be enabled by default. This includes a short explanation about why the CSS is required.

Feel free to review and/or adjust or reword accordingly.