### PR TITLE
Rework canvas access check and warning

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -109,19 +109,17 @@ Performance issues in the underlying `d3-cloud` layout can be encountered in the
 The `options.enableOptimizations` flag can be uesd to solve the first two performance problems. For the other problems, you will have to experiment and pick ideal options to configure your wordclouds.
 
 ### Browser-based
-`react-wordcloud` requires access to canvas data to render.  If browsers are blocking canvas data access (e.g. Firefox's `privacy.resistFingerprinting = true`), you need to enable it.  If you are implementing projects that use `react-wordcloud`, you should inform users on how to get around the issue as shown in the example below:
+`react-wordcloud` requires access to canvas data to render.  If browsers are blocking canvas data access (e.g. Firefox's `privacy.resistFingerprinting = true` which prompts for permission to access canvas data), you need to enable it.  If you are implementing projects that use `react-wordcloud`, you should inform users on how to get around the issue as shown in the example below:
 
 ```js
 function MyWordcloud(props) {
-  let entries = [];
-  performance.mark('check');
-  entries = performance.getEntries();
+  const canvasAllowed = typeof document !== 'undefined' && document.createElement('canvas').getContext('2d').getImageData(0, 0, 1, 1).data.every(v => v === 0);
 
-  if (entries.length === 0) {
+  if (!canvasAllowed) {
     return (
       <p>
         React wordcloud requires access to canvas image data. Please allow
-        access in your browser and try again.
+        access in your browser and reload the page.
       </p>
     );
   }

--- a/docs/react-wordcloud.tsx
+++ b/docs/react-wordcloud.tsx
@@ -8,18 +8,13 @@ import ReactWordcloudSrc, { Props } from '..';
 export * from '..';
 
 export default function ReactWordcloud(props: Props): JSX.Element {
-  let entries = [];
+  const canvasAllowed = typeof document !== 'undefined' && document.createElement('canvas').getContext('2d').getImageData(0, 0, 1, 1).data.every(v => v === 0);
 
-  if (typeof window !== 'undefined') {
-    window.performance.mark('check');
-    entries = window.performance.getEntries();
-  }
-
-  if (entries.length === 0) {
+  if (!canvasAllowed) {
     return (
       <p>
         React wordcloud requires access to canvas image data. Please allow
-        access in your browser and try again.
+        access in your browser and reload the page.
       </p>
     );
   }


### PR DESCRIPTION
I was trying out the changes discussed in #44 and noted the previous implementation was checking whether a setting like
`privacy.resistFingerprinting` was enabled rather than checking whether access is granted to the canvas API directly.
Enabling `privacy.resistFingerprinting` means the browser displays the prompt for a user to grant permission upon first access of canvas data such that access can be granted on a site-by-site basis, either temporarily or permantently.

This PR changes the access check to directly examine the result of trying to extract data from a fake, blank canvas. If anything but zeroes appear when checking data (e.g. a "non blank" canvas), such as the random integers Firefox returns, then it can safely determined that the browser is blocking canvas access.

For the wordcloud homepage, this means that because a timer is employed, enabling the canvas access immediately sees the wordcloud starting to work, without even needing to reload.

I also made a small change to reword the "try again" text -- instructing the user to reload, since that'll be what's required on most applications for the test to be re-run.

Ref: #44