### PR TITLE
Fix re-rendering when no parameters have changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,6 @@ function ReactWordCloud({
   words,
   ...rest
 }) {
-  const mergedCallbacks = { ...defaultCallbacks, ...callbacks };
-  const mergedOptions = { ...defaultOptions, ...options };
-
   const [ref, selection, size] = useResponsiveSvgSelection(
     minSize,
     initialSize,
@@ -48,6 +45,9 @@ function ReactWordCloud({
 
   useEffect(() => {
     if (selection) {
+      const mergedCallbacks = { ...defaultCallbacks, ...callbacks };
+      const mergedOptions = { ...defaultOptions, ...options };
+
       render.current({
         callbacks: mergedCallbacks,
         maxWords,
@@ -57,7 +57,7 @@ function ReactWordCloud({
         words,
       });
     }
-  }, [maxWords, mergedCallbacks, mergedOptions, selection, size, words]);
+  }, [maxWords, callbacks, options, selection, size, words]);
 
   return <div ref={ref} style={{ height: '100%', width: '100%' }} {...rest} />;
 }


### PR DESCRIPTION
Despite what the docs say the word cloud will still frequently re-render. This is due to the creation of the merged callbacks and options objects on every render. React hooks only check that 2 objects are actually the same object, not that they contain the same things, causing the hook to fire every time the function is called.