### PR TITLE
Fix tooltip's interactivity

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -52,11 +52,18 @@ export function render({ callbacks, options, random, selection, words }) {
           }
         })
         .on('mouseover', word => {
-          if (enableTooltip) {
+          if (
+            enableTooltip &&
+            (!tooltipInstance || tooltipInstance.isDestroyed)
+          ) {
             tooltipInstance = tippy(event.target, {
               animation: 'scale',
               arrow: true,
               content: () => getWordTooltip(word),
+              onHidden: (instance) => {
+                instance.destroy();
+                tooltipInstance = null;
+              },
               ...tooltipOptions,
             });
           }
@@ -66,7 +73,7 @@ export function render({ callbacks, options, random, selection, words }) {
           }
         })
         .on('mouseout', word => {
-          if (tooltipInstance) {
+          if (tooltipInstance && !tooltipInstance.state.isVisible) {
             tooltipInstance.destroy();
           }
 


### PR DESCRIPTION
The problem with interactive tooltips disappearing was because of this code block:

https://github.com/chrisrzhou/react-wordcloud/blob/1f6c3d009a3eaa2b1ced075619f820236a7e54a2/src/layout.js#L69-L71

It destroys the tooltip right after cursor leaves the word and moves towards tooltip. To fix it, I added an additional condition:
```js
if (tooltipInstance && !tooltipInstance.state.isVisible) {
```

After making this change, I had to add destruction logic for interactive logic, as you can see on lines 55-66.