### PR TITLE
`initRender` options for better UX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ function ReactWordCloud({
   options,
   size: initialSize,
   words,
+  initRender,
   ...rest
 }) {
   const [ref, selection, size] = useResponsiveSvgSelection(
@@ -55,6 +56,7 @@ function ReactWordCloud({
         selection,
         size,
         words,
+        initRender,
       });
     }
   }, [maxWords, callbacks, options, selection, size, words]);

--- a/src/layout.js
+++ b/src/layout.js
@@ -131,6 +131,7 @@ export function layout({
   selection,
   size,
   words,
+  initRender,
 }) {
   const MAX_LAYOUT_ATTEMPTS = 10;
   const SHRINK_FACTOR = 0.95;
@@ -217,6 +218,15 @@ export function layout({
             minFontSize,
           );
 
+          if (attempts === 1 && initRender) {
+            render({
+              callbacks,
+              options,
+              random,
+              selection,
+              words: computedWords,
+            })
+          }
           draw([minFontSize, maxFontSize], attempts + 1);
         } else {
           render({


### PR DESCRIPTION
`react-wordcloud` is so good because it automatically calulates the max size of font to show all words.

But, it is too slow to loading if maxFontSize of `fontSizes` options is too bigger. because it recurvely calll draw function to find the optimized max value of fontSize.

So I propose `initRender` options of `ReactWordcloud`.

`initRender` options is drawing tag-cloud when first attempts during caclulate the maxFontSize. I think It's better user experiance than wating loading completed.