### PR TITLE
Update d3 dependencies to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "types/index.d.ts"
   ],
   "dependencies": {
-    "d3-array": "^2.5.0",
+    "d3-array": "3",
     "d3-cloud": "^1.2.5",
     "d3-dispatch": "^1.0.6",
     "d3-scale": "^3.2.1",
-    "d3-scale-chromatic": "^1.5.0",
-    "d3-selection": "^1.4.2",
-    "d3-transition": "^1.3.2",
+    "d3-scale-chromatic": "3",
+    "d3-selection": "3",
+    "d3-transition": "3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "resize-observer-polyfill": "^1.5.1",
@@ -45,11 +45,11 @@
     "tippy.js": "^6.2.6"
   },
   "devDependencies": {
-    "@types/d3-array": "^2.0.0",
+    "@types/d3-array": "3",
     "@types/d3-cloud": "^1.2.3",
-    "@types/d3-scale": "^2.2.0",
-    "@types/d3-scale-chromatic": "^1.5.0",
-    "@types/d3-selection": "^1.4.1",
+    "@types/d3-scale": "3",
+    "@types/d3-scale-chromatic": "3",
+    "@types/d3-selection": "3",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.debounce": "^4.0.6",
     "@types/seedrandom": "^2.4.28",

--- a/src/layout.js
+++ b/src/layout.js
@@ -2,7 +2,6 @@ import 'd3-transition';
 
 import { descending } from 'd3-array';
 import d3Cloud from 'd3-cloud';
-import { event } from 'd3-selection';
 import clonedeep from 'lodash.clonedeep';
 import seedrandom from 'seedrandom';
 import tippy from 'tippy.js';
@@ -46,12 +45,12 @@ export function render({ callbacks, options, random, selection, words }) {
     enter => {
       let text = enter
         .append('text')
-        .on('click', word => {
+        .on('click', (event, word) => {
           if (onWordClick) {
             onWordClick(word, event);
           }
         })
-        .on('mouseover', word => {
+        .on('mouseover', (event, word) => {
           if (
             enableTooltip &&
             (!tooltipInstance || tooltipInstance.isDestroyed)
@@ -72,7 +71,7 @@ export function render({ callbacks, options, random, selection, words }) {
             onWordMouseOver(word, event);
           }
         })
-        .on('mouseout', word => {
+        .on('mouseout', (event, word) => {
           if (tooltipInstance && !tooltipInstance.state.isVisible) {
             tooltipInstance.destroy();
           }

--- a/src/optimized-d3-cloud.js
+++ b/src/optimized-d3-cloud.js
@@ -128,7 +128,7 @@ export default function Cloud() {
   function getContext(canvas) {
     canvas.width = canvas.height = 1;
     const ratio = Math.sqrt(
-      canvas.getContext('2d').getImageData(0, 0, 1, 1).data.length >> 2,
+      canvas.getContext('2d', { willReadFrequently: true }).getImageData(0, 0, 1, 1).data.length >> 2,
     );
     canvas.width = (cw << 5) / ratio;
     canvas.height = ch / ratio;
@@ -344,7 +344,7 @@ function cloudSprite(contextAndRatio, d, data, di) {
     d.hasText = true;
     x += w;
   }
-  const pixels = c.getImageData(0, 0, (cw << 5) / ratio, ch / ratio).data,
+  const pixels = c.getImageData(0, 0, (cw << 5) / ratio, ch / ratio,).data,
     sprite = [];
   while (--di >= 0) {
     d = data[di];


### PR DESCRIPTION
This PR updates outdated dependencies `d3-array`, `d3-selection` and `d3-transition` as well as other D3-* packages to version 3. The only incompatibility was the removal of `d3 event`. Relevant code was updated to use the new syntax. 
Fixes #85 